### PR TITLE
Improve phrasing of "depicts" question

### DIFF
--- a/api/resources/views/image-focus.blade.php
+++ b/api/resources/views/image-focus.blade.php
@@ -23,17 +23,17 @@
                 </div>
                 <div class="flex justify-center pt-8 sm:justify-start sm:pt-0">
                     <div class="text-lg leading-7 font-semibold text-gray-900 dark:text-white">Does this image actually clearly depict
-                        <a href="https://www.wikidata.org/wiki/{{$qu->properties['depicts_id']}}" target="_blank">
-                        {{ $qu->properties['depicts_id'] }} <u>{{ $qu->properties['depicts_name'] }}</u>
-                        </a>
+                        "{{ $qu->properties['depicts_name'] }}"
+                        (<a href="https://www.wikidata.org/wiki/{{$qu->properties['depicts_id']}}" target="_blank">
+                        {{ $qu->properties['depicts_id'] }}</a>)?
                     </div>
                 </div>
                 @else
                 <div class="flex justify-center pt-8 sm:justify-start sm:pt-0">
                     <div class="text-lg leading-7 font-semibold text-gray-900 dark:text-white">Does this image clearly depict
-                        <a href="https://www.wikidata.org/wiki/{{$qu->properties['depicts_id']}}" target="_blank">
-                        {{ $qu->properties['depicts_id'] }} <u>{{ $qu->properties['depicts_name'] }}</u>
-                        </a>
+                        "{{ $qu->properties['depicts_name'] }}"
+                        (<a href="https://www.wikidata.org/wiki/{{$qu->properties['depicts_id']}}" target="_blank">
+                        {{ $qu->properties['depicts_id'] }}</a>)?
                     </div>
                 </div>
                 @endif


### PR DESCRIPTION
Cognitively it's easier to see the name of the item followed by its QID than the opposite. This is also helpful in mobile phones, where screen space is more limited.

The underlining is also removed because it is typically associated with a link, when in this case the QID is (also) linked. Alternatively, we could keep the item name inside the link and underline the whole thing (though that would be better done via CSS than the `<u>` tag).

Finally, a question mark is added to make the sentence grammatically correct :)

Before:
![Screenshot from 2022-01-09 12-16-06](https://user-images.githubusercontent.com/478237/148681994-f2d9b266-1319-4bdf-8795-c062be6da8df.png)

After:
![Screenshot from 2022-01-09 12-17-12](https://user-images.githubusercontent.com/478237/148681995-53755e02-70e2-4e8b-a622-eed49c82faa1.png)