### PR TITLE
Add link to image page in depicts question

### DIFF
--- a/api/app/Jobs/GenerateDepictsQuestions.php
+++ b/api/app/Jobs/GenerateDepictsQuestions.php
@@ -72,8 +72,7 @@ class GenerateDepictsQuestions implements ShouldQueue
      *
      * @return void
      */
-    public function handle()
-    {
+    public function handle() {
         $this->createQuestionGroups();
 
         // Figure out how many questions for the category we already have
@@ -201,8 +200,8 @@ class GenerateDepictsQuestions implements ShouldQueue
 
         $ids = [];
         foreach ( $result['results']['bindings'] as $binding ) {
-			$ids[] = $this->getLastPartOfUrlPath( $binding['i']['value'] );
-		}
+            $ids[] = $this->getLastPartOfUrlPath( $binding['i']['value'] );
+        }
         return $ids;
     }
 
@@ -215,16 +214,16 @@ class GenerateDepictsQuestions implements ShouldQueue
 
         $ids = [];
         foreach ( $result['results']['bindings'] as $binding ) {
-			$ids[] = $this->getLastPartOfUrlPath( $binding['i']['value'] );
-		}
+            $ids[] = $this->getLastPartOfUrlPath( $binding['i']['value'] );
+        }
         return $ids;
     }
 
     private function getLastPartOfUrlPath( string $urlPath ): string {
-		// Assume that the last part is always the ID?
-		$parts = explode( '/', $urlPath );
-		return end( $parts );
-	}
+        // Assume that the last part is always the ID?
+        $parts = explode( '/', $urlPath );
+        return end( $parts );
+    }
 
     private function processFilePage( PageIdentifier $filePageIdentifier ) : bool {
         $wmFactory = (new \Addwiki\Wikimedia\Api\WikimediaFactory());

--- a/api/app/Jobs/GenerateDepictsQuestions.php
+++ b/api/app/Jobs/GenerateDepictsQuestions.php
@@ -314,7 +314,6 @@ class GenerateDepictsQuestions implements ShouldQueue
                     'old_depicts_name' => $lessSpecificItemLabel->getText(),
                     'depicts_id' => $this->depictItemId,
                     'depicts_name' => $this->depictName,
-                    'img_title' => $filePageIdentifier->getTitle()->getText(),
                     'img_url' => $thumbUrl,
                 ]
             ]);
@@ -333,7 +332,6 @@ class GenerateDepictsQuestions implements ShouldQueue
                 'mediainfo_id' => $mid->getSerialization(),
                 'depicts_id' => $this->depictItemId,
                 'depicts_name' => $this->depictName,
-                'img_title' => $filePageIdentifier->getTitle()->getText(),
                 'img_url' => $thumbUrl,
             ]
         ]);

--- a/api/app/Jobs/GenerateDepictsQuestions.php
+++ b/api/app/Jobs/GenerateDepictsQuestions.php
@@ -314,6 +314,7 @@ class GenerateDepictsQuestions implements ShouldQueue
                     'old_depicts_name' => $lessSpecificItemLabel->getText(),
                     'depicts_id' => $this->depictItemId,
                     'depicts_name' => $this->depictName,
+                    'img_title' => $filePageIdentifier->getTitle()->getText(),
                     'img_url' => $thumbUrl,
                 ]
             ]);
@@ -332,6 +333,7 @@ class GenerateDepictsQuestions implements ShouldQueue
                 'mediainfo_id' => $mid->getSerialization(),
                 'depicts_id' => $this->depictItemId,
                 'depicts_name' => $this->depictName,
+                'img_title' => $filePageIdentifier->getTitle()->getText(),
                 'img_url' => $thumbUrl,
             ]
         ]);

--- a/api/resources/views/image-focus.blade.php
+++ b/api/resources/views/image-focus.blade.php
@@ -42,7 +42,7 @@
                 </div>
 
                 <div class="flex flex-row justify-center items-start" style="height:800px;width:800px;">
-                    <a href="https://commons.wikimedia.org/wiki/{{ $qu->properties['img_title'] }}">
+                    <a href="https://commons.wikimedia.org/wiki/{{ $qu->properties['img_title'] }}" target="_blank">
                         <img class="object-contain align-top" style="object-position:top" src="{{ $qu->properties['img_url'] }}"></img>
                     </a>
                 </div>

--- a/api/resources/views/image-focus.blade.php
+++ b/api/resources/views/image-focus.blade.php
@@ -42,7 +42,7 @@
                 </div>
 
                 <div class="flex flex-row justify-center items-start" style="height:800px;width:800px;">
-                    <a href="https://commons.wikimedia.org/wiki/{{ $qu->properties['img_title'] }}" target="_blank">
+                    <a href="https://commons.wikimedia.org/wiki/Special:EntityData/{{ $qu->properties['mediainfo_id'] }}" target="_blank">
                         <img class="object-contain align-top" style="object-position:top" src="{{ $qu->properties['img_url'] }}"></img>
                     </a>
                 </div>

--- a/api/resources/views/image-focus.blade.php
+++ b/api/resources/views/image-focus.blade.php
@@ -42,7 +42,9 @@
                 </div>
 
                 <div class="flex flex-row justify-center items-start" style="height:800px;width:800px;">
-                    <img class="object-contain align-top" style="object-position:top" src="{{ $qu->properties['img_url'] }}"></img>
+                    <a href="https://commons.wikimedia.org/wiki/{{ $qu->properties['img_title'] }}">
+                        <img class="object-contain align-top" style="object-position:top" src="{{ $qu->properties['img_url'] }}"></img>
+                    </a>
                 </div>
             </div>
 


### PR DESCRIPTION
This is an attempt to make it possible to click the image to open the file page in Wikimedia Commons.
That would allow e.g. checking for existing image annotations, opening the image at full size to confirm details, checking the categories, description, etc. — all of which could help with making the "depicts" decision.

In addition, I added a cleanup commit harmonizing the whitespace in `GenerateDepictsQuestions.php`.
