### PR TITLE
Show aliases as a list

### DIFF
--- a/resources/views/html-focus.blade.php
+++ b/resources/views/html-focus.blade.php
@@ -16,7 +16,8 @@
                 </div>
                 <div class="flex justify-center pt-8 sm:justify-start sm:pt-0">
                     @if ($qu->properties['aliases'])
-                    <div class="text-sm leading-7 font-semibold text-gray-900 dark:text-white">Current Aliases:</div>&nbsp;<div class="text-md leading-7 text-gray-900 dark:text-white">{{ implode( ', ', $qu->properties['aliases']) }}</div>
+                    <div class="text-sm leading-7 font-semibold text-gray-900 dark:text-white">Current Aliases:</div>&nbsp;
+                    <ul class="text-md leading-7 text-gray-900 dark:text-white"><li>{{ implode( '</li></li>', $qu->properties['aliases']) }}</li></ul>
                     @else
                     <div class="text-sm leading-7 font-semibold text-gray-900 dark:text-white">Current Aliases:</div>&nbsp;<div class="text-md leading-7 text-gray-900 dark:text-white"></div>
                     @endif


### PR DESCRIPTION
This makes it easier to parse items that have many aliases .

Before:

![Screenshot from 2022-04-02 15-52-14](https://user-images.githubusercontent.com/478237/161388845-e137e9c5-38d0-4937-995c-5f68511d6f1d.png)

After: 

![Screenshot from 2022-04-02 15-51-06](https://user-images.githubusercontent.com/478237/161388842-01fa3c42-1c27-4ebc-bafa-cd9b21f677b7.png)

Note: The way I implemented the change in this PR is probably a terribly hacky way to go about it, but I think it gets the idea across :) feel free to adjust the code to something more elegant!