### PR TITLE
camera: exclude "photos taken with" categories

### DIFF
--- a/spec/depicts/misc/camera.yaml
+++ b/spec/depicts/misc/camera.yaml
@@ -9,4 +9,4 @@ exclude:
   - Category:Camera showrooms
   - Category:Camera accessories
   - Category:Photographs by camera manufacturer
-excludeRegex: "/(in art|Taken with)/"
+excludeRegex: "/(in art|Taken with)/i"


### PR DESCRIPTION
Not sure if category exclusions are recursive. If they're not, this PR is pretty much useless, since almost all of the contents of [Category:Photographs by camera manufacturer](https://commons.wikimedia.org/wiki/Category:Photographs_by_camera_manufacturer) are in its subcategories.

Assuming this works, it would fix some instances of "depicts a camera" questions, like [File:View from Mount Seymour Trail.jpg](https://commons.wikimedia.org/wiki/File:View_from_Mount_Seymour_Trail.jpg), which is in [Category:Taken with Olympus Air A01](https://commons.wikimedia.org/wiki/Category:Taken_with_Olympus_Air_A01).