### PR TITLE
Fix: Correct viewBox attribute for 'yes' icon in GridMode

### DIFF
--- a/resources/js/components/GridMode.vue
+++ b/resources/js/components/GridMode.vue
@@ -154,7 +154,7 @@
             </svg>
           </template>
           <template v-else>
-            <svg class="w-16 h-16 text-white" fill="none" stroke="currentColor" stroke-width="4" viewBox="0 24 24">
+            <svg class="w-16 h-16 text-white" fill="none" stroke="currentColor" stroke-width="4" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
             </svg>
           </template>


### PR DESCRIPTION
The SVG icon displayed when an image answer was 'yes' had an invalid viewBox attribute "0 24 24". This was missing a value and caused a console error: "Error: attribute viewBox: Unexpected end of attribute. Expected number, "0 24 24"".

This commit corrects the viewBox to "0 0 24 24", resolving the console error.

Relates to #140