### PR TITLE
Fix: Add check for Wikimedia disambiguation category Q15407973

### DIFF
--- a/resources/js/components/CustomDepictsGrid.vue
+++ b/resources/js/components/CustomDepictsGrid.vue
@@ -189,6 +189,13 @@ async function checkIfCategoryQid(qid) {
         showGrid.value = false;
         return true;
       }
+      // Check for Wikimedia disambiguation category
+      if (p31.some(s => s.mainsnak?.datavalue?.value?.id === 'Q15407973')) {
+        isCategoryQid.value = true;
+        categoryQidWarning.value = 'This Qid is a Wikimedia disambiguation category. Please use a specific item instead.';
+        showGrid.value = false;
+        return true;
+      }
     }
     isCategoryQid.value = false;
     categoryQidWarning.value = '';


### PR DESCRIPTION
The `CustomDepictsGrid.vue` component was previously checking for disambiguation items (Q4167410) to prevent their use on the custom page.

This commit extends this check to also include 'Q15407973', which represents "Wikimedia disambiguation category". Items belonging to this category should also not be used on the custom depicts grid page.

The `checkIfCategoryQid` function has been updated to include this additional check. If a QID matches 'Q15407973', `isCategoryQid` will be set to true, a warning message will be displayed, and the grid will not be shown.