### PR TITLE
Link 'depict' text in grid view to Wikimedia Commons

### DIFF
--- a/resources/js/components/GridMode.vue
+++ b/resources/js/components/GridMode.vue
@@ -3,7 +3,7 @@
     <div class="sticky top-0 z-20 bg-white bg-opacity-95 pb-2 mb-2 shadow">
       <h2 class="text-xl font-bold mb-2 flex flex-col items-center">
         <p class="text-lg leading-7 text-gray-500 mb-1">
-          Does this image clearly depict
+          Does this image clearly <a href="https://commons.wikimedia.org/wiki/Commons:Depicts" target="_blank" class="text-blue-600 hover:underline">depict</a>
         </p>
         <div v-if="images[0]?.properties?.depicts_id" class="text-lg font-semibold flex items-center mb-1">
           <a


### PR DESCRIPTION
This commit updates the grid view to include a hyperlink on the word 'depict' in the phrase "Does this image clearly depict". The link directs you to the Wikimedia Commons page explaining the concept of "depicts".

The change involves modifying the `GridMode.vue` component to wrap the word 'depict' with an anchor tag. The link is configured to open in a new tab for your convenience.