### PR TITLE
Fix deprecated string interpolation in SwapDepicts.php

### DIFF
--- a/app/Jobs/SwapDepicts.php
+++ b/app/Jobs/SwapDepicts.php
@@ -181,7 +181,7 @@ class SwapDepicts implements ShouldQueue
                 "https://query.wikidata.org/sparql",
                 PrefixSets::WIKIDATA
             ))->newWikibaseQueryService();
-            $result = $query->query( "SELECT DISTINCT ?i WHERE{?i wdt:P31/wdt:P279*|wdt:P279/wdt:P279* wd:${itemId} }" );
+            $result = $query->query( "SELECT DISTINCT ?i WHERE{?i wdt:P31/wdt:P279*|wdt:P279/wdt:P279* wd:{$itemId} }" );
 
             $ids = [];
             foreach ( $result['results']['bindings'] as $binding ) {


### PR DESCRIPTION
The usage of ${var} in strings is deprecated in PHP. This commit updates the code to use {$var} instead.

This addresses the PHP Deprecated warning: Using ${var} in strings is deprecated, use {$var} instead in /data/project/wikicrowd/public_html/app/Jobs/SwapDepicts.php on line 184.