### PR TITLE
Correct SPARQL 'up' queries to latest version

### DIFF
--- a/app/Jobs/GenerateDepictsQuestions.php
+++ b/app/Jobs/GenerateDepictsQuestions.php
@@ -308,11 +308,11 @@
                 "https://query.wikidata.org/sparql",
                 PrefixSets::WIKIDATA
             ))->newWikibaseQueryService();
-            $result = $query->query( "SELECT DISTINCT ?i WHERE{wd:${itemId} wdt:P279+ ?i }" );
+            $result = $query->query( "SELECT DISTINCT ?item ?itemLabel WHERE { {wd:${itemId} (wdt:P31/wdt:P279)+ ?item.} UNION {wd:${itemId} (wdt:P31/wdt:P279|wdt:P279)+ ?item .} SERVICE wikibase:label { bd:serviceParam wikibase:language \"[AUTO_LANGUAGE],mul,en\". } }" );
 
             $ids = [];
             foreach ( $result['results']['bindings'] as $binding ) {
-                $ids[] = $this->getLastPartOfUrlPath( $binding['i']['value'] );
+                $ids[] = $this->getLastPartOfUrlPath( $binding['item']['value'] );
             }
             return $ids;
         }

--- a/resources/js/components/DepictsGroupsFromYaml.vue
+++ b/resources/js/components/DepictsGroupsFromYaml.vue
@@ -116,7 +116,7 @@
               <template v-if="q.depictsId">
                 <div class="text-xs">
                   <a
-                    :href="`https://query.wikidata.org/embed.html#${encodeURIComponent(`SELECT DISTINCT ?item ?itemLabel WHERE { {wd:${q.depictsId.replace(/\{\{Q\|([^}]+)\}\}/, '$1')} (wdt:P31/wdt:P279)+ ?item.} UNION {wd:${q.depictsId.replace(/\{\{Q\|([^}]+)\}\}/, '$1')} (wdt:P31/wdt:P279|wdt:P279)+ ?item .} SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". } }`)}`"
+                    :href="getDepictsUpQueryUrl(q.depictsId)"
                     target="_blank"
                     rel="noopener"
                     class="text-blue-700 hover:underline"
@@ -500,6 +500,13 @@ const clearUnanswered = async (q) => {
     console.error('Error clearing unanswered questions:', e);
   }
   // Do not re-enable the button
+};
+
+const getDepictsUpQueryUrl = (depictsId) => {
+  if (!depictsId) return '';
+  const cleanId = depictsId.replace(/\{\{Q\|([^}]+)\}\}/, '$1');
+  const sparql = `SELECT DISTINCT ?item ?itemLabel WHERE { {wd:${cleanId} (wdt:P31/wdt:P279)+ ?item.} UNION {wd:${cleanId} (wdt:P31/wdt:P279|wdt:P279)+ ?item .} SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". } }`;
+  return 'https://query.wikidata.org/embed.html#' + encodeURIComponent(sparql);
 };
 
 </script>

--- a/resources/js/components/DepictsGroupsFromYaml.vue
+++ b/resources/js/components/DepictsGroupsFromYaml.vue
@@ -116,7 +116,7 @@
               <template v-if="q.depictsId">
                 <div class="text-xs">
                   <a
-                    :href="`https://query.wikidata.org/embed.html#SELECT%20%3Fitem%20%3FitemLabel%0AWHERE%0A%7B%0A%20%20wd%3A${q.depictsId.replace(/\{\{Q\|([^}]+)\}\}/, '$1')}%20wdt%3AP279%2B%20%3Fitem.%0A%20%20SERVICE%20wikibase%3Alabel%20%7B%20bd%3AserviceParam%20wikibase%3Alanguage%20%22%5BAUTO_LANGUAGE%5D%2Cmul%2Cen%22.%20%7D%0A%7D`"
+                    :href="`https://query.wikidata.org/embed.html#${encodeURIComponent(`SELECT DISTINCT ?item ?itemLabel WHERE { {wd:${q.depictsId.replace(/\{\{Q\|([^}]+)\}\}/, '$1')} (wdt:P31/wdt:P279)+ ?item.} UNION {wd:${q.depictsId.replace(/\{\{Q\|([^}]+)\}\}/, '$1')} (wdt:P31/wdt:P279|wdt:P279)+ ?item .} SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". } }`)}`"
                     target="_blank"
                     rel="noopener"
                     class="text-blue-700 hover:underline"

--- a/resources/js/components/GridMode.vue
+++ b/resources/js/components/GridMode.vue
@@ -16,7 +16,7 @@
           <span class="ml-1">(<WikidataLabel :qid="images[0].properties.depicts_id" :fallback="images[0].properties.depicts_name" />)</span>
           <span class="ml-2 text-sm">
             <a
-              :href="`https://query.wikidata.org/embed.html#SELECT%20%3Fitem%20%3FitemLabel%0AWHERE%0A%7B%0A%20%20wd%3A${images[0].properties.depicts_id}%20wdt%3AP279%2B%20%3Fitem.%0A%20%20SERVICE%20wikibase%3Alabel%20%7B%20bd%3AserviceParam%20wikibase%3Alanguage%20%22%5BAUTO_LANGUAGE%5D%2Cmul%2Cen%22.%20%7D%0A%7D`"
+              :href="`https://query.wikidata.org/embed.html#${encodeURIComponent(`SELECT DISTINCT ?item ?itemLabel WHERE { {wd:${images[0].properties.depicts_id} (wdt:P31/wdt:P279)+ ?item.} UNION {wd:${images[0].properties.depicts_id} (wdt:P31/wdt:P279|wdt:P279)+ ?item .} SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". } }`)}`"
               target="_blank"
               class="text-blue-600 hover:underline"
             >(up)</a>

--- a/resources/js/components/GridMode.vue
+++ b/resources/js/components/GridMode.vue
@@ -16,7 +16,7 @@
           <span class="ml-1">(<WikidataLabel :qid="images[0].properties.depicts_id" :fallback="images[0].properties.depicts_name" />)</span>
           <span class="ml-2 text-sm">
             <a
-              :href="`https://query.wikidata.org/embed.html#${encodeURIComponent(`SELECT DISTINCT ?item ?itemLabel WHERE { {wd:${images[0].properties.depicts_id} (wdt:P31/wdt:P279)+ ?item.} UNION {wd:${images[0].properties.depicts_id} (wdt:P31/wdt:P279|wdt:P279)+ ?item .} SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". } }`)}`"
+              :href="depictsUpQueryUrl"
               target="_blank"
               class="text-blue-600 hover:underline"
             >(up)</a>
@@ -232,7 +232,7 @@
 </template>
 
 <script>
-import { ref, onMounted, onUnmounted, reactive, watch } from 'vue'; // Added watch
+import { ref, onMounted, onUnmounted, reactive, watch, computed } from 'vue'; // Added computed
 import WikidataLabel from './WikidataLabel.vue';
 import WikidataDescription from './WikidataDescription.vue';
 import { fetchSubclassesAndInstances, fetchDepictsForMediaInfoIds } from './depictsUtils';
@@ -1286,6 +1286,14 @@ export default {
       imageLoadingStates[image.id] = 'loading';
     };
 
+    // --- Add computed property for the (up) SPARQL query link ---
+    const depictsUpQueryUrl = computed(() => {
+      const depictsId = images.value[0]?.properties?.depicts_id;
+      if (!depictsId) return '';
+      const sparql = `SELECT DISTINCT ?item ?itemLabel WHERE { {wd:${depictsId} (wdt:P31/wdt:P279)+ ?item.} UNION {wd:${depictsId} (wdt:P31/wdt:P279|wdt:P279)+ ?item .} SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". } }`;
+      return 'https://query.wikidata.org/embed.html#' + encodeURIComponent(sparql);
+    });
+
     // On mount, always add keyboard shortcuts
     let keydownHandler;
     onMounted(() => {
@@ -1468,6 +1476,7 @@ export default {
       openFullscreen,
       closeFullscreen,
       countdownTimers, // Added for template access
+      depictsUpQueryUrl, // Added computed property
     };
   },
 };


### PR DESCRIPTION
I've updated the SPARQL query used for finding parent items to the latest version you provided. The new query is:

SELECT DISTINCT ?item ?itemLabel WHERE {
  {wd:ITEMID (wdt:P31/wdt:P279)+ ?item.} UNION {wd:ITEMID (wdt:P31/wdt:P279|wdt:P279)+ ?item .}
  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". }
}

This corrects the previous update which used an intermediate version of the query.

Files updated:
- resources/js/components/DepictsGroupsFromYaml.vue
- resources/js/components/GridMode.vue
- app/Jobs/GenerateDepictsQuestions.php (parentInstancesOfAndSubclassesOf function)

Query curated as part of thinking in https://github.com/addshore/wikicrowd/issues/137