### PR TITLE
Fix: Disable auto-save when checkbox is unchecked in grid view.

### DIFF
--- a/resources/js/components/GridMode.vue
+++ b/resources/js/components/GridMode.vue
@@ -1136,8 +1136,6 @@ export default {
           imageClickQueue.value.push({ id, mode: selectedMode[id] }); // Use selectedMode[id] which is answerMode.value
 
           // Start/reset the main 1-second batchTimer
-          if (batchTimer.value) clearTimeout(batchTimer.value);
-          batchTimer.value = setTimeout(processClickQueue, 1000);
         }
       }
     };


### PR DESCRIPTION
The `toggleSelect` function in `resources/js/components/GridMode.vue` was incorrectly starting a timer for `processClickQueue` even when the `autoSave` checkbox was unchecked. This caused changes to be auto-saved regardless of your preference.

This commit removes the unnecessary timer initialization from the `else` block (when `autoSave.value` is `false`) in the `toggleSelect` function, ensuring that auto-save is truly disabled when the checkbox is not checked.