### PR TITLE
Fix: Ensure dynamic grid loads when category and item are provided

### DIFF
--- a/resources/js/components/CustomDepictsGrid.vue
+++ b/resources/js/components/CustomDepictsGrid.vue
@@ -314,6 +314,7 @@ onMounted(async () => {
     manualCategory.value = category;
     manualQid.value = item;
     await checkIfCategoryQid(item);
+    loadAll.value = false; // Ensure dynamic grid mode
     showGrid.value = canShowGrid();
     return;
   }


### PR DESCRIPTION
Explicitly sets `loadAll = false` in `CustomDepictsGrid.vue` when a category and item are provided via URL parameters. This ensures that the grid defaults to dynamic loading mode (not loading images below the fold) in this scenario, aligning with the expected behavior.

Also clarified to you that `saveAllPending` calls are expected behavior due to auto-save and selection batching, not necessarily requiring a manual click of the 'Save' button.