### PR TITLE
Fix: Adjust toast notification position to prevent overlap with navbar

### DIFF
--- a/resources/js/components/ToastNotification.vue
+++ b/resources/js/components/ToastNotification.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="fixed top-4 right-4 z-[10000] w-full max-w-xs sm:max-w-sm">
+  <div class="fixed top-16 right-4 z-40 w-full max-w-xs sm:max-w-sm">
     <transition-group name="toast-fade" tag="div" class="space-y-2">
       <div
         v-for="toast in toasts"


### PR DESCRIPTION
I changed the z-index of the toast container to be lower than the navbar and adjusted its top margin to ensure it displays below the navigation menu.

![image](https://github.com/user-attachments/assets/e27af119-fce0-4b10-81b5-5cd36d99382e)

Fixes https://github.com/addshore/wikicrowd/issues/168