### PR TITLE
Fix: Ensure 'Category:' prefix in manual depicts summary

### DIFF
--- a/app/Jobs/AddDepicts.php
+++ b/app/Jobs/AddDepicts.php
@@ -205,6 +205,9 @@ class AddDepicts implements ShouldQueue
             $editInfo = null;
             if (!empty($question->properties['manual']) && !empty($question->properties['category']) && !empty($question->properties['depicts_id'])) {
                 $cat = $question->properties['category'];
+                if (stripos($cat, 'Category:') !== 0) {
+                    $cat = 'Category:' . $cat;
+                }
                 $qid = $question->properties['depicts_id'];
                 $this->logContext['manual_cat'] = $cat;
                 $editInfo = new EditInfo("From custom inputs [[:$cat]] and [[wikidata:$qid]]");


### PR DESCRIPTION
When adding a 'depicts' statement from a custom input (manual mode), the edit summary is generated using the category name provided by the user. If the user does not include the 'Category:' prefix, the resulting summary will contain a red link.

This commit fixes the issue by ensuring that the category name in the edit summary is always prefixed with 'Category:'. It checks if the prefix exists (case-insensitively) and adds it if it's missing.