### PR TITLE
Fix: Do not validate deleted images in manual depicts mode

### DIFF
--- a/resources/js/components/GridMode.vue
+++ b/resources/js/components/GridMode.vue
@@ -1387,9 +1387,13 @@ export default {
           reason: `Failed to load after ${MAX_IMAGE_RETRIES} retries.`
         };
 
-        // Add to batch for server validation
-        console.log(`[GridMode] Image ${image.id} permanently failed to load. Adding to validation batch.`);
-        addToFailedImagesBatch(image.id);
+        // Add to batch for server validation, but only if not in manual mode
+        if (!props.manualMode) {
+          console.log(`[GridMode] Image ${image.id} permanently failed to load. Adding to validation batch.`);
+          addToFailedImagesBatch(image.id);
+        } else {
+          console.log(`[GridMode] Image ${image.id} (manual mode) permanently failed to load. No server validation needed.`);
+        }
       }
     };
 


### PR DESCRIPTION
When an image failed to load on the custom depicts grid (manual mode), the application would attempt to call the `/api/questions/validate-and-cleanup` endpoint. This was incorrect because images in manual mode are fetched directly from Wikimedia Commons and do not have a corresponding question record in the database.

This was causing a validation error because the frontend was sending the MediaInfo ID (e.g., "M12345") as a `question_id`, while the backend expects an integer database ID.

This patch fixes the issue by adding a check within the `handleImgError` function in `GridMode.vue`. The call to `addToFailedImagesBatch` (which triggers the validation) is now skipped if the component is in `manualMode`.

Could not run tests due to missing PHP and Composer in the environment.