### PR TITLE
feat: Make AddDepicts job unique to prevent race conditions

### DIFF
--- a/app/Http/Controllers/Api/AnswerController.php
+++ b/app/Http/Controllers/Api/AnswerController.php
@@ -61,7 +61,13 @@ class AnswerController extends Controller
                 $rank = ($answerValue === 'yes-preferred') ? 'preferred' : null;
                 $removeSuperclasses = $request->boolean('remove_superclasses', false);
                 if ($parentGroupName === 'depicts') {
-                    dispatch(new AddDepicts($storedAnswer->id, $rank, $removeSuperclasses));
+                    dispatch(new AddDepicts(
+                        $storedAnswer->id,
+                        $question->properties['mediainfo_id'],
+                        $question->properties['depicts_id'],
+                        $rank,
+                        $removeSuperclasses
+                    ));
                 }
             } else {
                 // Log if group or parentGroup is missing, as jobs might not be dispatched correctly
@@ -132,7 +138,13 @@ class AnswerController extends Controller
                     $rank = ($answerData['answer'] === 'yes-preferred') ? 'preferred' : null;
                     $removeSuperclasses = $request->boolean('remove_superclasses', false);
                     if ($parentGroupName === 'depicts') {
-                        dispatch(new AddDepicts($storedAnswer->id, $rank, $removeSuperclasses));
+                        dispatch(new AddDepicts(
+                            $storedAnswer->id,
+                            $question->properties['mediainfo_id'],
+                            $question->properties['depicts_id'],
+                            $rank,
+                            $removeSuperclasses
+                        ));
                     }
                 } else if ($question) {
                     \Log::warning("Question {$question->id} is missing group or parentGroup information. Answer ID: {$storedAnswer->id}");


### PR DESCRIPTION
This change refactors the AddDepicts job to prevent race conditions when multiple jobs are dispatched for the same media info and depicts item.

It implements the ShouldBeUnique interface, which is the recommended Laravel way to handle such cases. The unique ID for the job is generated from the mediainfo_id and depicts_id.

The AddDepicts job constructor is updated to accept these IDs, and the AnswerController is updated to pass them when dispatching the job.

This is a more robust and cleaner solution than manual locking.