### PR TITLE
Fix(ImageCard): Use stable Special:EntityData links for images

### DIFF
--- a/resources/js/components/ImageCard.vue
+++ b/resources/js/components/ImageCard.vue
@@ -191,23 +191,18 @@ export default {
   },
   computed: {
     filePageUrl() {
-      // For manual mode, use the title directly (e.g., "File:Example.jpg")
+      // Prioritize using MediaInfo ID for a stable link to the entity data page.
+      if (this.image.properties?.mediainfo_id) {
+        return `https://commons.wikimedia.org/wiki/Special:EntityData/${this.image.properties.mediainfo_id}`;
+      }
+
+      // Fallback for manual mode where a title might be available but no mediainfo_id.
       if (this.image.title) {
         return `https://commons.wikimedia.org/wiki/${encodeURIComponent(this.image.title)}`;
       }
       
-      // For API mode, extract filename from img_url and construct File: page URL
-      if (this.image.properties?.img_url) {
-        const filename = this.image.properties.img_url.substring(this.image.properties.img_url.lastIndexOf('/') + 1);
-        // Remove thumbnail size prefix (e.g., "960px-" from "960px-Kitten_(9169054156).jpg")
-        const cleanedFilename = filename.replace(/^\d+px-/, '');
-        // Decode the filename to get the original name
-        const decodedFilename = decodeURIComponent(cleanedFilename);
-        return `https://commons.wikimedia.org/wiki/File:${encodeURIComponent(decodedFilename)}`;
-      }
-      
-      // Fallback to MediaInfo if no filename available
-      return `https://commons.wikimedia.org/wiki/Special:EntityData/${this.image.properties?.mediainfo_id || this.image.id}`;
+      // If no identifier is available, do not generate a link.
+      return '#';
     }
   }
 };


### PR DESCRIPTION
The `filePageUrl` computed property in `ImageCard.vue` was previously constructing a `File:` page link by parsing the `img_url`. This was brittle and would fail for certain thumbnail URLs, such as those for videos or documents, which could result in incorrect links pointing to a generic `thumbnail.jpg`.

This change refactors the `filePageUrl` logic to prioritize using the `mediainfo_id` to create a stable and reliable link to the `Special:EntityData` page on Wikimedia Commons. This is consistent with the behavior in the fullscreen modal view and ensures that the link always points to the correct entity data page.

If the `mediainfo_id` is not available, it falls back to using the `image.title`. If neither is available, it returns `#` to avoid generating a broken link.

Fixes #213