### PR TITLE
Fix: Limit seen_ids in API requests to prevent long URLs

### DIFF
--- a/resources/js/components/GridMode.vue
+++ b/resources/js/components/GridMode.vue
@@ -436,7 +436,9 @@ export default {
       isFetchingMore.value = true;
       let url = `/api/questions/${groupName}?count=${BATCH_SIZE}`;
       if (seenIds.value.length > 0) {
-        url += `&seen_ids=${encodeURIComponent(seenIds.value.join(','))}`;
+        // Take the last 300 seen IDs to keep the URL length manageable.
+        const seenIdsToSend = seenIds.value.slice(-300);
+        url += `&seen_ids=${encodeURIComponent(seenIdsToSend.join(','))}`;
       }
       const headers = { 'Accept': 'application/json' };
       if (apiToken) headers['Authorization'] = `Bearer ${apiToken}`;


### PR DESCRIPTION
The API requests to fetch new questions could fail if the user had seen a large number of questions, leading to a URL that was too long.

This change modifies the frontend to only send the last 300 seen_ids to the server. This is enough to prevent recently seen items from reappearing without creating an excessively long URL.

Fixes #212