### PR TITLE
Do not remove statements with qualifiers

### DIFF
--- a/app/Jobs/AddDepicts.php
+++ b/app/Jobs/AddDepicts.php
@@ -183,7 +183,7 @@ class AddDepicts implements ShouldQueue, ShouldBeUnique
                 }
                 
                 // Collect superclass statements for potential removal
-                if( $this->removeSuperclasses && in_array( $entityId->getSerialization(), $parentClasses ) ) {
+                if( $this->removeSuperclasses && in_array( $entityId->getSerialization(), $parentClasses ) && $statement->getQualifiers()->isEmpty() ) {
                     $superclassStatements[] = $statement;
                 }
             }


### PR DESCRIPTION
When adding a more specific 'depicts' statement, the old, less specific statement would be removed.

This change prevents the removal of the old statement if it has qualifiers.