### PR TITLE
feat: Integrate with Wikimedia EditGroups 2

### DIFF
--- a/app/Http/Controllers/Api/AnswerController.php
+++ b/app/Http/Controllers/Api/AnswerController.php
@@ -29,6 +29,7 @@ class AnswerController extends Controller
             'question_id' => 'required|exists:App\Models\Question,id',
             'answer' => 'required|in:yes,no,skip,yes-preferred',
             'remove_superclasses' => 'boolean',
+            'edit_group_id' => 'nullable|string|max:255',
         ]);
 
         if ($validator->fails()) {
@@ -61,12 +62,14 @@ class AnswerController extends Controller
                 $rank = ($answerValue === 'yes-preferred') ? 'preferred' : null;
                 $removeSuperclasses = $request->boolean('remove_superclasses', false);
                 if ($parentGroupName === 'depicts') {
+                    $editGroupId = $request->input('edit_group_id');
                     dispatch(new AddDepicts(
                         $storedAnswer->id,
                         $question->properties['mediainfo_id'],
                         $question->properties['depicts_id'],
                         $rank,
-                        $removeSuperclasses
+                        $removeSuperclasses,
+                        $editGroupId
                     ));
                 }
             } else {
@@ -99,6 +102,7 @@ class AnswerController extends Controller
             'answers.*.question_id' => 'required|exists:App\\Models\\Question,id',
             'answers.*.answer' => 'required|in:yes,no,skip,yes-preferred',
             'remove_superclasses' => 'boolean',
+            'edit_group_id' => 'nullable|string|max:255',
         ]);
 
         if ($validator->fails()) {
@@ -138,12 +142,14 @@ class AnswerController extends Controller
                     $rank = ($answerData['answer'] === 'yes-preferred') ? 'preferred' : null;
                     $removeSuperclasses = $request->boolean('remove_superclasses', false);
                     if ($parentGroupName === 'depicts') {
+                        $editGroupId = $request->input('edit_group_id');
                         dispatch(new AddDepicts(
                             $storedAnswer->id,
                             $question->properties['mediainfo_id'],
                             $question->properties['depicts_id'],
                             $rank,
-                            $removeSuperclasses
+                            $removeSuperclasses,
+                            $editGroupId
                         ));
                     }
                 } else if ($question) {

--- a/app/Http/Controllers/Api/ManualQuestionController.php
+++ b/app/Http/Controllers/Api/ManualQuestionController.php
@@ -36,6 +36,7 @@ class ManualQuestionController extends Controller
             'img_url' => 'required|url',
             'answer' => 'required|in:yes,no,skip,yes-preferred',
             'remove_superclasses' => 'boolean',
+            'edit_group_id' => 'nullable|string|max:255',
         ]);
         if ($v->fails()) {
             return response()->json(['message' => 'Invalid input', 'errors' => $v->errors()], 422);
@@ -70,7 +71,15 @@ class ManualQuestionController extends Controller
             // Check for superclass depicts
             $rank = ($request->input('answer') === 'yes-preferred') ? 'preferred' : null;
             $removeSuperclasses = $request->boolean('remove_superclasses', false);
-            dispatch(new \App\Jobs\AddDepicts($answer->id, $rank, $removeSuperclasses));
+            $editGroupId = $request->input('edit_group_id');
+            dispatch(new \App\Jobs\AddDepicts(
+                $answer->id,
+                $request->input('mediainfo_id'),
+                $request->input('qid'),
+                $rank,
+                $removeSuperclasses,
+                $editGroupId
+            ));
         }
 
         return response()->json(['message' => 'Question answered', 'question_id' => $question->id, 'answer_id' => $answer->id]);
@@ -94,6 +103,7 @@ class ManualQuestionController extends Controller
             'answers.*.img_url' => 'required|url',
             'answers.*.answer' => 'required|in:yes,no,skip,yes-preferred',
             'remove_superclasses' => 'boolean',
+            'edit_group_id' => 'nullable|string|max:255',
         ]);
         if ($v->fails()) {
             return response()->json(['message' => 'Invalid input', 'errors' => $v->errors()], 422);
@@ -143,7 +153,15 @@ class ManualQuestionController extends Controller
             if ($input['answer'] === 'yes' || $input['answer'] === 'yes-preferred') {
                 $rank = ($input['answer'] === 'yes-preferred') ? 'preferred' : null;
                 $removeSuperclasses = $request->boolean('remove_superclasses', false);
-                dispatch(new \App\Jobs\AddDepicts($answer->id, $rank, $removeSuperclasses));
+                $editGroupId = $request->input('edit_group_id');
+                dispatch(new \App\Jobs\AddDepicts(
+                    $answer->id,
+                    $input['mediainfo_id'],
+                    $input['qid'],
+                    $rank,
+                    $removeSuperclasses,
+                    $editGroupId
+                ));
             }
             $results[] = [
                 'question_id' => $question->id,

--- a/resources/js/components/CustomDepictsGrid.vue
+++ b/resources/js/components/CustomDepictsGrid.vue
@@ -37,7 +37,7 @@
       </form>
     </div>
     <div class='w-full'>
-      <GridMode v-if="showGrid && canShowGrid()" :manual-category="manualCategory" :manual-qid="manualQid" :manual-mode="true" :load-all="loadAll" :key="gridKey" />
+      <GridMode v-if="showGrid && canShowGrid()" :manual-category="manualCategory" :manual-qid="manualQid" :manual-mode="true" :load-all="loadAll" :key="gridKey" :edit-group-id="editGroupId" />
     </div>
   </div>
 </template>
@@ -45,9 +45,11 @@
 <script setup>
 import { ref, onMounted, computed } from 'vue';
 import GridMode from './GridMode.vue';
+import { randomBytes } from 'crypto';
 
 const manualCategory = ref('');
 const manualQid = ref('');
+const editGroupId = ref('');
 const showGrid = ref(false);
 const gridKey = ref(0); // Used to force re-render of GridMode
 const loadAll = ref(false); // New data property
@@ -461,6 +463,7 @@ function canShowGrid() {
 }
 
 onMounted(async () => {
+  editGroupId.value = randomBytes(6).toString('hex');
   const categoryParam = getQueryParam('category');
   const itemParam = getQueryParam('item');
   const autoParam = getQueryParam('auto');

--- a/resources/js/components/GridMode.vue
+++ b/resources/js/components/GridMode.vue
@@ -187,7 +187,8 @@ export default {
     manualCategory: { type: String, default: '' },
     manualQid: { type: String, default: '' },
     manualMode: { type: Boolean, default: false },
-    loadAll: { type: Boolean, default: false }
+    loadAll: { type: Boolean, default: false },
+    editGroupId: { type: String, default: null },
   },
   setup(props) {
     const images = ref([]);
@@ -594,7 +595,8 @@ export default {
         body: JSON.stringify({
           question_id: image.id,
           answer: finalAnswerMode, // Use the determined mode for the API call
-          remove_superclasses: removeSuperclasses.value
+          remove_superclasses: removeSuperclasses.value,
+          edit_group_id: props.editGroupId
         })
       };
 
@@ -971,7 +973,8 @@ export default {
           img_url: image.properties.img_url,
           answer: finalAnswerMode, // Use the determined mode
           remove_superclasses: removeSuperclasses.value,
-          manual: true
+          manual: true,
+          edit_group_id: props.editGroupId
         })
       };
 
@@ -1079,7 +1082,8 @@ export default {
             headers,
             body: JSON.stringify({
               answers,
-              remove_superclasses: removeSuperclasses.value
+              remove_superclasses: removeSuperclasses.value,
+              edit_group_id: props.editGroupId
             }),
           };
           response = await fetchAnswerWithRetry(manualUrl, manualOptions);
@@ -1096,7 +1100,8 @@ export default {
             headers,
             body: JSON.stringify({
               answers,
-              remove_superclasses: removeSuperclasses.value
+              remove_superclasses: removeSuperclasses.value,
+              edit_group_id: props.editGroupId
             }),
           };
           response = await fetchAnswerWithRetry(regularUrl, regularOptions);


### PR DESCRIPTION
This change integrates the application with the Wikimedia EditGroups tool to allow for better tracking of batches of edits.

On the frontend:
- A unique Edit Group ID is generated when the `CustomDepictsGrid` component is created.
- This ID is passed down to the `GridMode` component and included in all answer submissions (single, bulk, and manual).

On the backend:
- The `AnswerController` and `ManualQuestionController` now accept an optional `edit_group_id`.
- The `AddDepicts` job has been updated to accept a nullable `editGroupId`.
- If an `editGroupId` is provided, a tracking link in the format `([[:toolforge:editgroups/b/wikicrowd/HASH|details]])` is appended to the edit summary.