### PR TITLE
feat: Detect mobile edits and add #mobile to summary

### DIFF
--- a/app/Http/Controllers/Api/AnswerController.php
+++ b/app/Http/Controllers/Api/AnswerController.php
@@ -30,6 +30,7 @@ class AnswerController extends Controller
             'answer' => 'required|in:yes,no,skip,yes-preferred',
             'remove_superclasses' => 'boolean',
             'edit_group_id' => 'nullable|string|max:255',
+            'is_mobile' => 'boolean',
         ]);
 
         if ($validator->fails()) {
@@ -63,13 +64,15 @@ class AnswerController extends Controller
                 $removeSuperclasses = $request->boolean('remove_superclasses', false);
                 if ($parentGroupName === 'depicts') {
                     $editGroupId = $request->input('edit_group_id');
+                    $isMobile = $request->boolean('is_mobile', false);
                     dispatch(new AddDepicts(
                         $storedAnswer->id,
                         $question->properties['mediainfo_id'],
                         $question->properties['depicts_id'],
                         $rank,
                         $removeSuperclasses,
-                        $editGroupId
+                        $editGroupId,
+                        $isMobile
                     ));
                 }
             } else {
@@ -103,6 +106,7 @@ class AnswerController extends Controller
             'answers.*.answer' => 'required|in:yes,no,skip,yes-preferred',
             'remove_superclasses' => 'boolean',
             'edit_group_id' => 'nullable|string|max:255',
+            'is_mobile' => 'boolean',
         ]);
 
         if ($validator->fails()) {
@@ -143,13 +147,15 @@ class AnswerController extends Controller
                     $removeSuperclasses = $request->boolean('remove_superclasses', false);
                     if ($parentGroupName === 'depicts') {
                         $editGroupId = $request->input('edit_group_id');
+                        $isMobile = $request->boolean('is_mobile', false);
                         dispatch(new AddDepicts(
                             $storedAnswer->id,
                             $question->properties['mediainfo_id'],
                             $question->properties['depicts_id'],
                             $rank,
                             $removeSuperclasses,
-                            $editGroupId
+                            $editGroupId,
+                            $isMobile
                         ));
                     }
                 } else if ($question) {

--- a/app/Jobs/AddDepicts.php
+++ b/app/Jobs/AddDepicts.php
@@ -34,6 +34,7 @@ class AddDepicts implements ShouldQueue, ShouldBeUnique
     private string $mediainfoId;
     private string $depictsId;
     private ?string $editGroupId;
+    private bool $isMobile;
 
     /**
      * Create a new job instance.
@@ -46,7 +47,8 @@ class AddDepicts implements ShouldQueue, ShouldBeUnique
         string $depictsId,
         ?string $rank = null,
         bool $removeSuperclasses = false,
-        ?string $editGroupId = null
+        ?string $editGroupId = null,
+        bool $isMobile = false
     ) {
         $this->answerId = $answerId;
         $this->rank = $rank;
@@ -54,6 +56,7 @@ class AddDepicts implements ShouldQueue, ShouldBeUnique
         $this->mediainfoId = $mediainfoId;
         $this->depictsId = $depictsId;
         $this->editGroupId = $editGroupId;
+        $this->isMobile = $isMobile;
 
         // Initialize logging context
         $this->logContext = [
@@ -63,6 +66,7 @@ class AddDepicts implements ShouldQueue, ShouldBeUnique
             'mediainfo_id' => $this->mediainfoId,
             'depicts_id' => $this->depictsId,
             'editGroupId' => $this->editGroupId,
+            'isMobile' => $this->isMobile,
         ];
     }
 
@@ -333,9 +337,18 @@ class AddDepicts implements ShouldQueue, ShouldBeUnique
 
     private function getEditInfoSummary(string $summary): string
     {
+        $summaryDetails = [];
         if ($this->editGroupId) {
-            return $summary . " ([[:toolforge:editgroups/b/wikicrowd/{$this->editGroupId}|details]])";
+            $summaryDetails[] = "[[:toolforge:editgroups/b/wikicrowd/{$this->editGroupId}|details]]";
         }
+        if ($this->isMobile) {
+            $summaryDetails[] = "#mobile";
+        }
+
+        if (!empty($summaryDetails)) {
+            return $summary . " (" . implode(' ', $summaryDetails) . ")";
+        }
+
         return $summary;
     }
 }

--- a/resources/js/components/GridMode.vue
+++ b/resources/js/components/GridMode.vue
@@ -207,6 +207,10 @@ export default {
     const apiToken = window.apiToken || null;
     const csrfToken = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
     const answerMode = ref('yes');
+
+    const isMobile = computed(() => {
+      return /Mobi/i.test(navigator.userAgent);
+    });
     
     // Initialize removeSuperclasses - set to true by default for all routes
     const removeSuperclasses = ref(true);
@@ -596,7 +600,8 @@ export default {
           question_id: image.id,
           answer: finalAnswerMode, // Use the determined mode for the API call
           remove_superclasses: removeSuperclasses.value,
-          edit_group_id: props.editGroupId
+          edit_group_id: props.editGroupId,
+          is_mobile: isMobile.value
         })
       };
 
@@ -974,7 +979,8 @@ export default {
           answer: finalAnswerMode, // Use the determined mode
           remove_superclasses: removeSuperclasses.value,
           manual: true,
-          edit_group_id: props.editGroupId
+          edit_group_id: props.editGroupId,
+          is_mobile: isMobile.value
         })
       };
 
@@ -1083,7 +1089,8 @@ export default {
             body: JSON.stringify({
               answers,
               remove_superclasses: removeSuperclasses.value,
-              edit_group_id: props.editGroupId
+              edit_group_id: props.editGroupId,
+              is_mobile: isMobile.value
             }),
           };
           response = await fetchAnswerWithRetry(manualUrl, manualOptions);
@@ -1101,7 +1108,8 @@ export default {
             body: JSON.stringify({
               answers,
               remove_superclasses: removeSuperclasses.value,
-              edit_group_id: props.editGroupId
+              edit_group_id: props.editGroupId,
+              is_mobile: isMobile.value
             }),
           };
           response = await fetchAnswerWithRetry(regularUrl, regularOptions);
@@ -2273,6 +2281,7 @@ export default {
       answerModeStyles,
       isHeaderCollapsed,
       toggleHeaderCollapse,
+      isMobile
     };
   },
 };


### PR DESCRIPTION
This feature detects when an editor is using a mobile browser and appends `#mobile` to the edit summary.

The implementation includes:
- A computed property in `GridMode.vue` to detect mobile user agents.
- Passing an `is_mobile` flag from the frontend to the backend when an answer is submitted.
- Handling the `is_mobile` flag in the `AnswerController` and passing it to the `AddDepicts` job.
- Updating the `AddDepicts` job to append `#mobile` to the edit summary if the flag is true.