### PR TITLE
I will generate the 'edit_group_id' on the client for the main grid.

### DIFF
--- a/resources/js/components/GridMode.vue
+++ b/resources/js/components/GridMode.vue
@@ -191,6 +191,10 @@ export default {
     editGroupId: { type: String, default: '' }
   },
   setup(props) {
+    const internalEditGroupId = ref(props.editGroupId);
+    if (!internalEditGroupId.value) {
+        internalEditGroupId.value = [...Array(12)].map(() => Math.floor(Math.random() * 16).toString(16)).join('');
+    }
     const images = ref([]);
     const seenIds = ref([]);
     const allLoaded = ref(false);
@@ -596,7 +600,7 @@ export default {
           question_id: image.id,
           answer: finalAnswerMode, // Use the determined mode for the API call
           remove_superclasses: removeSuperclasses.value,
-          edit_group_id: props.editGroupId
+          edit_group_id: internalEditGroupId.value
         })
       };
 
@@ -974,7 +978,7 @@ export default {
           answer: finalAnswerMode, // Use the determined mode
           remove_superclasses: removeSuperclasses.value,
           manual: true,
-          edit_group_id: props.editGroupId
+          edit_group_id: internalEditGroupId.value
         })
       };
 
@@ -1083,7 +1087,7 @@ export default {
             body: JSON.stringify({
               answers,
               remove_superclasses: removeSuperclasses.value,
-              edit_group_id: props.editGroupId
+              edit_group_id: internalEditGroupId.value
             }),
           };
           response = await fetchAnswerWithRetry(manualUrl, manualOptions);
@@ -1101,7 +1105,7 @@ export default {
             body: JSON.stringify({
               answers,
               remove_superclasses: removeSuperclasses.value,
-              edit_group_id: props.editGroupId
+              edit_group_id: internalEditGroupId.value
             }),
           };
           response = await fetchAnswerWithRetry(regularUrl, regularOptions);


### PR DESCRIPTION
Previously, the main question grid was not generating an 'edit_group_id', which caused bulk API answers to be sent with an empty ID. This could lead to issues with tracking and grouping edits.

I will fix this issue by generating the 'edit_group_id' on the client-side within the 'GridMode.vue' component. This ensures that a consistent ID is used for a user's entire session on the grid, which is the desired behavior and matches the implementation of the custom grid.

The component now checks if an 'editGroupId' is passed as a prop. If not, it generates a new random ID. This ID is then used in all API calls that submit answers.