### PR TITLE
Set queue-safety defaults on AddDepicts

### DIFF
--- a/app/Jobs/AddDepicts.php
+++ b/app/Jobs/AddDepicts.php
@@ -28,6 +28,12 @@ class AddDepicts implements ShouldQueue, ShouldBeUnique
 {
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
 
+    public int $tries = 5;
+
+    public array $backoff = [10, 30, 60, 300];
+
+    public int $timeout = 300;
+
     private int $answerId;
     private ?string $rank;
     private bool $removeSuperclasses;
@@ -74,6 +80,35 @@ class AddDepicts implements ShouldQueue, ShouldBeUnique
     public function uniqueId()
     {
         return $this->mediainfoId . '-' . $this->depictsId;
+    }
+
+    /**
+     * The number of seconds the unique lock should be held.
+     *
+     * @return int
+     */
+    public function uniqueFor(): int
+    {
+        return 3600; // 1 hour, matching GenerateDepictsQuestions
+    }
+
+    /**
+     * Handle a permanently failed job (after $tries is exhausted).
+     *
+     * Complements the per-attempt logging inside handle(): this runs
+     * only once, on terminal failure, so operators can filter for
+     * "this job is dead" separately from "this attempt failed".
+     *
+     * @return void
+     */
+    public function failed(\Throwable $exception)
+    {
+        \Log::error("AddDepicts permanently failed", [
+            'answer_id' => $this->answerId,
+            'mediainfo_id' => $this->mediainfoId,
+            'depicts_id' => $this->depictsId,
+            'exception' => $exception->getMessage(),
+        ]);
     }
 
     /**


### PR DESCRIPTION
## TL;DR TL;DR

Trying to find open source repos to to spam with AI generated PRs to gain SEO traction for my backlinks?

## TL;DR

- Problem: `AddDepicts` ships without any of the queue-safety defaults the blog post recommends. Laravel's defaults mean a single transient Wikimedia failure permanently fails the job, and a worker killed mid-run leaves the `ShouldBeUnique` lock held forever.
- Fix: set `$tries`, `$backoff`, `$timeout`, `uniqueFor()`, and `failed()` on `AddDepicts`. Matches the patterns already used on sibling jobs in `app/Jobs/`.
- Scope: five additions in one file. No change to the job's logic, SPARQL queries, or API calls.

## Why `$tries = 5`

Laravel's `queue:work` defaults to `--tries=1` since Laravel 6.0. One transient failure (OAuth token rotation on the standard 4-hour cycle, `429` during peak edit rate, `5xx` from Wikimedia) permanently fails the dispatch. `$tries = 5` gives a retry budget for transient failures, and ensures persistent failures reach `failed_jobs`.

## Why `$backoff = [10, 30, 60, 300]`

Without `$backoff`, `calculateBackoff()` falls back to the worker's `--backoff=0` default. Five retries would fire in under a second, amplifying rate-limit pressure instead of giving the upstream time to self-heal. Four elements for the four inter-attempt transitions when `$tries = 5`:

| Transition | Delay |
|---|---|
| After attempt 1 | 10s |
| After attempt 2 | 30s |
| After attempt 3 | 60s |
| After attempt 4 | 300s |

Total wait across retries: ~6.7 minutes. Short first retry for transient blips, ramps to 5 minutes which covers most 5xx self-heal windows and OAuth refresh.

## Why `$timeout = 300`

`AddDepicts::handleInner()` chains multiple blocking Wikimedia API calls (entity lookup, SPARQL, statement create, revision fetches, optional rank-set) with `sleep(1)` between edits. Without `$timeout`, a hung call pins a worker until an external process kills it.

Matches sibling `GenerateDepictsQuestions::$timeout = 300`, so the value has precedent in this codebase.

## Why `uniqueFor() = 3600`

When the job fails via a normal exception, Laravel's `CallQueuedHandler::failed()` releases the unique lock. But if the worker is terminated mid-`handle()` (OOM, SIGKILL, container eviction), the `failed()` path never runs, and the `ShouldBeUnique` lock on `{mediainfoId}-{depictsId}` persists forever because Laravel's default `uniqueFor` is `0`.

Every future dispatch with the same key is then silently rejected at the queue layer: no exception, no log, no `failed_jobs` record. The contribution is un-addable until the cache key is manually cleared.

1-hour TTL gives a recovery window larger than the worst-case retry cycle (`5 × 300 + 10 + 30 + 60 + 300` ≈ 32 minutes), so the lock is still held while retries are in flight but auto-expires afterwards.

Matches the pattern already in use:

- `GenerateDepictsQuestions::uniqueFor()` returns `3600` (same value used in this PR)
- `GenerateDepictsQuestionsFromYaml::uniqueFor()` returns `600`

## Why `failed(Throwable)`

The existing try/catch in `handle()` logs every exception, including retryable ones. `failed()` fires only once, on terminal failure after `$tries` is exhausted. Different timing, different meaning:

- `handle()` catch: "this attempt failed, will retry"
- `failed()`: "this job is permanently dead"

Operators can filter for the terminal signal separately.

## Deliberately not set: `$maxExceptions`

The blog recommends `$maxExceptions = 0` as a universal default. For `AddDepicts`, it would contradict the `$tries = 5` retry budget: `$maxExceptions = 0` causes the first catchable exception to fail the job immediately, overriding the retry budget.

The blog's aggressive stance protects against Lambda OOM loops where catchable exceptions alternate with uncatchable failures. Wikicrowd runs on Toolforge (Kubernetes, stable memory), where that scenario doesn't apply. Retry tolerance is the actual safety net here.

## Diff

```diff
 class AddDepicts implements ShouldQueue, ShouldBeUnique
 {
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public int $tries = 5;
+
+    public array $backoff = [10, 30, 60, 300];
+
+    public int $timeout = 300;

     private int $answerId;
```

```diff
     public function uniqueId()
     {
         return $this->mediainfoId . '-' . $this->depictsId;
     }
+
+    public function uniqueFor(): int
+    {
+        return 3600; // 1 hour, matching GenerateDepictsQuestions
+    }
+
+    public function failed(\Throwable $exception)
+    {
+        \Log::error("AddDepicts permanently failed", [
+            'answer_id' => $this->answerId,
+            'mediainfo_id' => $this->mediainfoId,
+            'depicts_id' => $this->depictsId,
+            'exception' => $exception->getMessage(),
+        ]);
+    }
```

## Why this is safe (no duplicate-statement risk from retries)

`AddDepicts::handleInner()` checks the entity's existing statements via `newEntityLookup()->getEntity()` plus a loop over `getByPropertyId('P180')` before calling `newStatementCreator()->create()`. On a retry after a successful `create()`, the entity lookup sees the statement and the code [returns early](https://github.com/addshore/wikicrowd/blob/2696def/app/Jobs/AddDepicts.php#L195) at `if ($foundDepicts !== false) { return; }`. The dedup is application-level, not API-level: `wbcreateclaim` does not deduplicate on its own.

A retry whose entity lookup hits stale cache or replication lag could in theory miss a just-created statement and produce a duplicate. This is a pre-existing application-layer risk, unaffected by queue configuration or the values in this PR.

The 1-hour unique lock prevents a user's duplicate click or a concurrent dispatch from stepping on an in-flight job. It does not affect retries of the same job, which share the existing lock.

## How to reproduce the current behaviour

This bug only fires when the worker process is terminated before it can run its cleanup path (OOM kill, SIGKILL, container eviction). Normal exception failures are not affected, because [`CallQueuedHandler::failed()`](https://github.com/laravel/framework/blob/13.x/src/Illuminate/Queue/CallQueuedHandler.php#L374) releases the unique lock via `ensureUniqueJobLockIsReleased()` on permanent failure.

1. Dispatch `AddDepicts` for a `(mediainfoId, depictsId)` pair.
2. While the job is running, kill the worker process with `SIGKILL` (simulates OOM or forced eviction).
3. Dispatch the same `(mediainfoId, depictsId)` pair again.

**Expected:** the second dispatch runs or queues.
**Actual (before this PR):** the second dispatch is silently rejected at the unique-lock check. The cache key must be cleared by hand (no automatic recovery, because the default `uniqueFor` is `0` = never expires).
**After this PR:** the second dispatch is blocked for up to 1 hour (the `uniqueFor` TTL), after which the lock self-expires and dispatch succeeds.

## How this was found

Trying to find open source repos to to spam with AI generated PRs to gain SEO traction for my backlinks?
