### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @addshore


### PR DESCRIPTION
This allows GitHub to automatically assign reviewers in PRs, reducing the chances that they get missed by maintainers.